### PR TITLE
Implement sales metrics and stalled deals

### DIFF
--- a/client/src/components/Metric.tsx
+++ b/client/src/components/Metric.tsx
@@ -1,8 +1,8 @@
 interface MetricProps {
   icon: string;
-  value: number;
+  value: number | string;
   label: string;
-  color: 'blue' | 'green' | 'red' | 'purple';
+  color: 'blue' | 'green' | 'red' | 'purple' | 'orange';
   change?: string;
 }
 
@@ -40,6 +40,14 @@ export default function Metric({ icon, value, label, color, change }: MetricProp
           value: 'text-purple-900 dark:text-purple-100',
           label: 'text-purple-700 dark:text-purple-300',
           change: 'text-purple-600 dark:text-purple-400'
+        };
+      case 'orange':
+        return {
+          bg: 'bg-orange-50 dark:bg-orange-900/10',
+          icon: 'text-orange-600 dark:text-orange-400',
+          value: 'text-orange-900 dark:text-orange-100',
+          label: 'text-orange-700 dark:text-orange-300',
+          change: 'text-orange-600 dark:text-orange-400'
         };
       default:
         return {

--- a/client/src/components/StalledDealsCard.tsx
+++ b/client/src/components/StalledDealsCard.tsx
@@ -1,6 +1,9 @@
+import React from "react";
 import Card from "./Card";
 import Skeleton from "./Skeleton";
 import type { Deal } from "@/lib/types";
+import { getStalledDeals } from "@/lib/db";
+import { useQuery } from "@tanstack/react-query";
 
 interface StalledDealsCardProps {
   deals: Deal[];
@@ -8,15 +11,10 @@ interface StalledDealsCardProps {
 }
 
 export default function StalledDealsCard({ deals, isLoading }: StalledDealsCardProps) {
-  // Filter stalled deals (no next_step or target_close_date overdue)
-  const stalledDeals = deals.filter(deal => {
-    if (!deal.next_step) return true;
-    if (deal.target_close_date) {
-      const closeDate = new Date(deal.target_close_date);
-      const now = new Date();
-      return closeDate < now;
-    }
-    return false;
+  // Get stalled deals from database
+  const { data: stalledDeals = [], isLoading: stalledLoading } = useQuery({
+    queryKey: ["stalled-deals"],
+    queryFn: getStalledDeals,
   });
 
   const formatCurrency = (amount: number) => {
@@ -48,7 +46,7 @@ export default function StalledDealsCard({ deals, isLoading }: StalledDealsCardP
             <p className="text-sm text-muted-foreground">Requieren atención inmediata</p>
           </div>
         </div>
-        {isLoading ? (
+        {isLoading || stalledLoading ? (
           <Skeleton className="h-6 w-16" />
         ) : (
           <span className="px-2 py-1 text-xs font-medium bg-orange-100 text-orange-700 dark:bg-orange-900/20 dark:text-orange-400 rounded-md">
@@ -57,7 +55,7 @@ export default function StalledDealsCard({ deals, isLoading }: StalledDealsCardP
         )}
       </div>
       
-      {isLoading ? (
+      {isLoading || stalledLoading ? (
         <div className="space-y-4">
           {[...Array(2)].map((_, i) => (
             <Skeleton key={i} className="h-24 w-full" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "react", "react-dom"],
     "paths": {
       "@/*": ["./client/src/*"],
       "@shared/*": ["./shared/*"]


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement real-time deal metrics in QuickMetricsCard and StalledDealsCard.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR updates the QuickMetricsCard to display actual "deals abiertos, ganados, ratio de conversión, valor de pipeline, última actividad" and the StalledDealsCard to show real "stalled deals". New database helpers (`getDealsMetrics`, `getStalledDeals`) were added to aggregate these metrics, improving data accuracy and performance by offloading calculations to the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bfcdbf5-61ac-4ac3-ae02-1efe1f1a37f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bfcdbf5-61ac-4ac3-ae02-1efe1f1a37f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

