### PR TITLE
Fix undefined monthlyMetrics in QuickMetricsCard

### DIFF
--- a/client/src/components/QuickMetricsCard.tsx
+++ b/client/src/components/QuickMetricsCard.tsx
@@ -2,7 +2,6 @@ import Card from "@/components/Card";
 import Metric from "@/components/Metric";
 import Skeleton from "@/components/Skeleton";
 import type { Task, Deal } from "@/lib/types";
-import { isThisMonth } from "date-fns";
 
 interface QuickMetricsCardProps {
   tasks: Task[];
@@ -17,6 +16,12 @@ export default function QuickMetricsCard({ tasks, deals, isLoading }: QuickMetri
   const currentYear = now.getFullYear();
 
   const isCurrentMonth = (dateString: string | null) => {
+    if (!dateString) return false;
+    const date = new Date(dateString);
+    return date.getMonth() === currentMonth && date.getFullYear() === currentYear;
+  };
+
+  const isThisMonth = (dateString: string | null) => {
     if (!dateString) return false;
     const date = new Date(dateString);
     return date.getMonth() === currentMonth && date.getFullYear() === currentYear;


### PR DESCRIPTION
Remove `date-fns` import and replace `isThisMonth` with a custom implementation to fix a runtime error.

The `date-fns` import was failing at runtime, which prevented the `monthlyMetrics` variable from being defined, leading to the 'monthlyMetrics is not defined' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fffa21f-608d-4390-8fc6-8ca5d6ccdb92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fffa21f-608d-4390-8fc6-8ca5d6ccdb92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

