### PR TITLE
Fix null contact name to lower case error

### DIFF
--- a/client/src/components/ContactsList.tsx
+++ b/client/src/components/ContactsList.tsx
@@ -87,8 +87,8 @@ export default function ContactsList({ className }: ContactsListProps) {
   const filteredContacts = useMemo(() => {
     return contacts.filter((contact) => {
       const matchesSearch = 
-        contact.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        contact.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (contact.name && contact.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+        (contact.email && contact.email.toLowerCase().includes(searchTerm.toLowerCase())) ||
         (contact.company && contact.company.toLowerCase().includes(searchTerm.toLowerCase()));
       
       return matchesSearch;


### PR DESCRIPTION
Add null checks for `contact.name` and `contact.email` to prevent runtime errors when these properties are null.

The `Contact` interface defines `name` and `email` as `string`, but runtime data showed instances where these properties were `null`, causing a `Cannot read properties of null (reading 'toLowerCase')` error when attempting to call `.toLowerCase()` on them. This PR adds defensive checks to handle such cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-971401ce-bec8-47d6-90be-fc0c5661c40a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-971401ce-bec8-47d6-90be-fc0c5661c40a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

